### PR TITLE
RFC: Add ?account= and ?balances-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v1.0.7
+
+- Started this changelog

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: protocol.html diagrams
 
 protocol.html: protocol.md style.css pandoc_template.html CHANGELOG.md
-	( cat protocol.md ; echo '# Changes' ; echo ''; cat CHANGELOG.md | sed -e s/#/##/g ) | pandoc \
+	( cat protocol.md | sed -e s/VERSIONTAG/$$(changer current-version)/ ; echo '# Changes' ; echo ''; cat CHANGELOG.md | sed -e s/#/##/g ) | pandoc \
 		-s -c style.css \
 		--metadata title="SimpleFIN Protocol" \
 		--toc --toc-depth=2 \

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 all: protocol.html diagrams
 
-protocol.html: protocol.md style.css pandoc_template.html
-	cat protocol.md | pandoc \
+protocol.html: protocol.md style.css pandoc_template.html CHANGELOG.md
+	( cat protocol.md ; echo '# Changes' ; echo ''; cat CHANGELOG.md | sed -e s/#/##/g ) | pandoc \
 		-s -c style.css \
 		--metadata title="SimpleFIN Protocol" \
 		--toc --toc-depth=2 \

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,36 @@
+`changer` makes it easy to manage a `CHANGELOG.md` file.  It works in Nim projects and other languages, too.
+
+# Installation
+
+```
+nimble install changer
+```
+
+# Configuration
+
+You can configure how `changer` behaves by editing the `changes/config.toml` file.
+
+# Usage
+
+Start a changelog in a project by running:
+
+    changer init
+
+Every time you want to add something to the changelog, make a new Markdown file in `./changes/` named like this:
+
+  - `fix-NAME.md`
+  - `new-NAME.md`
+  - `break-NAME.md`
+  - `other-NAME.md`
+
+Use the tool to add a changelog entry:
+
+    changer add
+
+When you're ready to release a new version, preview the new changelog with:
+
+    changer bump -n
+
+Then make the new changelog (and update the version of any `.nimble` file):
+
+    changer bump

--- a/changes/config.toml
+++ b/changes/config.toml
@@ -1,0 +1,30 @@
+update_nimble = true
+update_package_json = true
+
+# Replacements are string substitutions using
+# https://nitely.github.io/nim-regex/regex.html#replace%2Cstring%2CRegex%2Cstring%2Cint
+# They run on each snippet in the order defined, before the snippet is
+# added to the CHANGELOG.md file.
+#
+# For example, uncomment the following lines to replace issue numbers with
+# links to your GitHub project.
+
+# [[replacement]]
+# pattern = '#(\d+)'
+# replace = "[#$1](https://github.com/YOURNAME/YOURPROJECT/issues/$1)"
+
+
+# Duplications are directories that you want to duplicate
+# changelog entries to.
+#
+# For example, uncomment the following and then any time
+# you add a change with `changer add`, it will create a
+# change snippet in these directories:
+#   ./changes
+#   ./changes/../../componentB/changes
+#   ./changes/../../componentC/changes
+
+# [[duplicate]]
+# dst = '../../componentB/changes'
+# [[duplicate]]
+# dst = '../../componentC/changes'

--- a/changes/new-Added-GET-accountsaccount-20241016-221658.md
+++ b/changes/new-Added-GET-accountsaccount-20241016-221658.md
@@ -1,0 +1,1 @@
+Added `GET /accounts?account=` parameter for filtering which accounts are returned.

--- a/changes/new-Added-GET-accountsbalances-only1-20241016-221726.md
+++ b/changes/new-Added-GET-accountsbalances-only1-20241016-221726.md
@@ -1,0 +1,1 @@
+Added `GET /accounts?balances-only=1` parameter to skip fetching account transaction data.

--- a/protocol.md
+++ b/protocol.md
@@ -1,8 +1,8 @@
 
 <img src="img/logo.svg" style="width: 32px; height: 32px;" align="center"> SimpleFIN Protocol
 
-- Version: 1.0-draft.7
-- Last modified: 05 Jun 2024
+- Version: 1.1.0
+- Last modified: 16 Oct 2024
 
 # Introduction
 
@@ -632,6 +632,8 @@ Retrieve account and transaction data.
 | start-date | optional | If given, transactions will be restricted to those on or after this Unix epoch timestamp. |
 | end-date | optional | If given, transactions will be restricted to those before (**but not on**) this Unix epoch timestamp. |
 | pending | optional | If `pending=1` is provided, pending transactions will be included (if supported). By default, pending transaction are **NOT** included. |
+| account | optional | If given, only return information related to the given account id. May be specified multiple times. |
+| balances-only | optional | If `balances-only=1` is provided, no transaction data is returned. |
 
 ### Authentication
 

--- a/protocol.md
+++ b/protocol.md
@@ -1,8 +1,7 @@
 
 <img src="img/logo.svg" style="width: 32px; height: 32px;" align="center"> SimpleFIN Protocol
 
-- Version: 1.1.0
-- Last modified: 16 Oct 2024
+- Version: VERSIONTAG
 
 # Introduction
 


### PR DESCRIPTION
This change adds 2 parameters to the GET /accounts endpoint:

- `account=ACCOUNTID` - to only retrieve data for the specified accounts
- `balances-only=1` - to skip getting transaction data and only return balance info